### PR TITLE
Fix groff font escape in manpage

### DIFF
--- a/doc/mseed2sac.1
+++ b/doc/mseed2sac.1
@@ -166,7 +166,7 @@ A metadata file contains a list of station parameters, some of which
 can be stored in SAC but not in miniSEED.  Each line in a metadata
 file should be a list of parameters in the order shown below.  Each
 parameter should be separated with a comma or a vertical bar (|).
-\fbDIP CONVENTION:\fP When comma separators are used the dip field
+\fBDIP CONVENTION:\fP When comma separators are used the dip field
 (CMPINC) is assumed to be in the SAC convention (degrees down from
 vertical up/outward), if vertical bars are used the dip field is
 assumed to be in the SEED convention (degrees down from horizontal)


### PR DESCRIPTION
Fix a lowercase `\fb` font escape in `doc/mseed2sac.1`.

The intent is to switch to bold text, so the correct groff escape is `\fB`.
The current spelling triggers this warning when formatting the manpage:

      troff:<standard input>:169: warning: cannot select font 'b'

This was found while cleaning up the Debian package lintian output.

